### PR TITLE
Different brace style to fix weird if statements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -30,5 +30,5 @@ AlignOperands: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 2
 IndentAccessModifiers: true
-ColumnLimit: 0
+ColumnLimit: 90
 Standard: c++03


### PR DESCRIPTION
changes this:
```c
if (x) {
    a = b;
}
```
into this:
```c
if (x)
{
    a = b;
}
```

(which I thought I had already done, but apparently not..)