### PR TITLE
Hotfix: now updates the pollable with the new index of its pollfd str…

### DIFF
--- a/code/includes/ipollable/ClientFD.hpp
+++ b/code/includes/ipollable/ClientFD.hpp
@@ -58,4 +58,5 @@ class ClientFD : public IPollable {
 		int32_t getRemainderBytes() const;
 		void    timeout();
 		bool    isClosed() const;
+		void    setIndex(int32_t index);
 };

--- a/code/includes/ipollable/FileFD.hpp
+++ b/code/includes/ipollable/FileFD.hpp
@@ -39,4 +39,5 @@ class FileFD : public IPollable {
 		RequestInterface *_requestInterface;
 		ClientFD         *_client;
 		bool              isClosed() const;
+		void              setIndex(int32_t index);
 };

--- a/code/includes/ipollable/IPollable.hpp
+++ b/code/includes/ipollable/IPollable.hpp
@@ -18,4 +18,5 @@ class IPollable {
 		virtual bool    isClosed() const          = 0;
 		virtual int     getFileDescriptor() const = 0;
 		virtual Server *getServer() const         = 0;
+		virtual void    setIndex(int32_t index)   = 0;
 };

--- a/code/includes/ipollable/ServerFD.hpp
+++ b/code/includes/ipollable/ServerFD.hpp
@@ -20,4 +20,5 @@ class ServerFD : public IPollable {
 		Server *getServer() const;
 		void    timeout();
 		bool    isClosed() const;
+		void    setIndex(int32_t index);
 };

--- a/code/source_files/ipollable/ClientFD.cpp
+++ b/code/source_files/ipollable/ClientFD.cpp
@@ -240,3 +240,7 @@ void ClientFD::timeout() {
 bool ClientFD::isClosed() const {
 	return _closed;
 }
+
+void ClientFD::setIndex(int32_t index) {
+	_index = index;
+}

--- a/code/source_files/ipollable/FileFD.cpp
+++ b/code/source_files/ipollable/FileFD.cpp
@@ -81,3 +81,7 @@ void FileFD::timeout() {
 bool FileFD::isClosed() const {
 	return _closed;
 }
+
+void FileFD::setIndex(int32_t index) {
+	_index = index;
+}

--- a/code/source_files/ipollable/ServerFD.cpp
+++ b/code/source_files/ipollable/ServerFD.cpp
@@ -52,3 +52,7 @@ void ServerFD::timeout() {
 bool ServerFD::isClosed() const {
 	return _closed;
 }
+
+void ServerFD::setIndex(int32_t index) {
+	_index = index;
+}

--- a/code/source_files/server/Server.cpp
+++ b/code/source_files/server/Server.cpp
@@ -125,6 +125,7 @@ void Server::run() {
 			it = Server::_pollables.find(Server::_pfds[i].fd);
 			assert(it != Server::_pollables.end());
 			assert(it->second->getFileDescriptor() != -1);
+			it->second->setIndex(i);
 			it->second->timeout();
 			if (it->second->isClosed() == true) {
 				removePollable(i);


### PR DESCRIPTION
Hotfix: now updates the pollable with the new index of its pollfd struct every poll cycle, including after removal.