### PR TITLE
Let clang/gcc make dependency files with `-MMD` flag

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -11,10 +11,6 @@ ifdef EXTRA_CFLAGS
 	CXXFLAGS += $(EXTRA_CFLAGS)
 endif
 
-ifdef CXX14
-	CXX := /Volumes/Data_v/utils/homebrew/opt/llvm/bin/clang++
-endif
-
 # # # # # # # # # # # # # # # # # # # #
 #			  MAKE HELPERS			  #
 # # # # # # # # # # # # # # # # # # # #
@@ -25,15 +21,15 @@ uniqlist 	= $(if $1,$(firstword $1) $(call uniqlist,$(filter-out $(firstword $1)
 #			  DIRECTORIES			  #
 # # # # # # # # # # # # # # # # # # # #
 
-OBJ_DIR		:= object_files/
-SRC_DIR		:= source_files/
-INC_DIR		:= includes/
+OBJ_DIR		:= object_files
+SRC_DIR		:= source_files
+INC_DIR		:= includes
 
 # # # # # # # # # # # # # # # # # # # #
 #			  SOURCE_FILES			  #
 # # # # # # # # # # # # # # # # # # # #
 
-MAIN		:= $(SRC_DIR)main.cpp
+MAIN		:= $(SRC_DIR)/main.cpp
 
 # a list of classes without the .cpp suffix!
 CLASSES		:= config/ConfigParser\
@@ -53,33 +49,36 @@ CLASSES		:= config/ConfigParser\
 				autoindex/Autoindex\
 				config/MimeTypes
 
-OBJECTS		:= $(CLASSES:%=$(OBJ_DIR)%.o)
-HEADERS		:= $(CLASSES:%=$(INC_DIR)%.hpp)
+OBJECTS		:= $(CLASSES:%=$(OBJ_DIR)/%.o)
+OBJECTS     += $(OBJ_DIR)/main.o
+
+# These .d files will contain dependencies
+DEP			:= $(OBJECTS:%.o=%.d)
+
+HEADERS		:= $(CLASSES:%=$(INC_DIR)/%.hpp)
 
 UNIQ_DIRS	:= $(call uniqlist, $(foreach class, $(CLASSES), $(firstword $(subst /, , $(class)))))
 
-CPPFLAGS	:= -I$(INC_DIR)
-CPPFLAGS	+= $(foreach dir, $(UNIQ_DIRS), $(join -I$(INC_DIR),$(dir)))
+CPPFLAGS	:= -I$(INC_DIR)/
+CPPFLAGS	+= $(foreach dir, $(UNIQ_DIRS), $(join -I$(INC_DIR)/,$(dir)))
+
 
 # # # # # # # # # # # # # # # # # # # #
 #				  RULES				  #
 # # # # # # # # # # # # # # # # # # # #
 
+$(NAME): $(OBJECTS)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OBJECTS) -o $(NAME)
+
+# include all .d files
+-include $(DEP)
+
 all: $(NAME)
 
-$(NAME): $(OBJECTS) $(MAIN)
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OBJECTS) $(MAIN) -o $(NAME)
-
-$(OBJ_DIR)%.o: $(SRC_DIR)%.cpp $(HEADERS)
-	mkdir -p $(OBJ_DIR) $(dir $@)
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
-
-tidy:
-	/Volumes/Data_v/utils/homebrew/opt/llvm/bin/clang-tidy $(CLASSES:%=$(SRC_DIR)%.cpp) -- $(CPPFLAGS)
-
-errorpages:
-	cd utilities && $(CC) html_errorpage_generator.c && ./a.out
-	$(RM) ./utilities/a.out
+# $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp $(HEADERS)
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
+	mkdir -p $(OBJ_DIR)/ $(dir $@)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -MMD -c $< -o $@
 
 clean:
 	$(RM) -r $(OBJ_DIR)


### PR DESCRIPTION
creates `%.d` files containing a list of dependencies for that `%.o` file

Which makes it so that when you change 1 header file, which is used in 2 cpp files, only those two cpp files get recompiled, instead of everything (like it was before)