### PR TITLE
maxHeaderSize

### DIFF
--- a/code/includes/utils/Defines.hpp
+++ b/code/includes/utils/Defines.hpp
@@ -8,6 +8,7 @@
 #define CRLF_LEN        2
 #define CRLF_LEN2       4
 #define TIMEOUT_SECONDS 5
+#define MAX_HEADER_SIZE 8196
 #define BUFFERSIZE      10000 // tmp
 
 enum PollableType { SERVERPOLL, CLIENTPOLL, FILEPOLL };

--- a/code/source_files/ipollable/ClientFD.cpp
+++ b/code/source_files/ipollable/ClientFD.cpp
@@ -120,9 +120,13 @@ void ClientFD::sendResponse() {
 */
 
 void ClientFD::receiveHeader() {
-	size_t end = 0;
+	size_t end = _inbound.find(CRLF_END);
 
-	if ((end = _inbound.find(CRLF_END)) != std::string::npos) {
+	if (end != std::string::npos && end > MAX_HEADER_SIZE) {
+		throw(Utils::ErrorPageException("413"));
+	} else if (end == std::string::npos && _inbound.size() > MAX_HEADER_SIZE) {
+		throw(Utils::ErrorPageException("413"));
+	} else if (end != std::string::npos) {
 		this->_request.ParseRequest(this->_inbound);
 		this->_request.printAttributesInRequestClass();
 		this->_config   = this->_server->findConfig(this->_request);


### PR DESCRIPTION
DON'T MERGE YET

Stop receiving more bytes when the end of a header is not found within MAX_HEADER_SIZE bytes. Return 413 error response.

Now segfaults (while using default config).